### PR TITLE
make mk.js run in node js

### DIFF
--- a/minikanren.js
+++ b/minikanren.js
@@ -316,16 +316,21 @@ var mk_test = function(proto, index) {
   */
   function do_test ( ) {
     var handler = function ( ) {
+      var expected = proto.expected.apply
+          ? proto.expected
+          : (function ( ) { return proto.expected; })
+          ;
       try {
-        return assert_equals(name, proto.body, proto.expected);
+        return assert_equals(name, proto.body.apply(this, arguments), expected.apply(this, arguments));
       } catch (e) {
         console.error("Exception raised during", name, "-> ", e.stack);
       }
     };
     if (proto.fresh && proto.body && proto.body.call) {
-      return (function ( ) { return fresh(proto.fresh, handler); })
+      console.log('returning with fresh');
+      return (function ( ) { return fresh(proto.fresh, handler); }).apply(this, arguments);
     } else {
-      return handler;
+      return handler.apply(this, arguments);
     }
   }
   /*

--- a/minikanren.js
+++ b/minikanren.js
@@ -289,31 +289,6 @@ var mk_test = function(proto, index) {
     console.error('test '+name+' discarded.. Must be lazy !');
     return null;
   }
-  /*
-  if( proto.fresh !== undefined ) {// fresh
-    var vars = proto.fresh.split(' ').reduce(function(code, v) { return (code.length===0)?'$'+v:code+', $'+v; }, '');
-    var fresh_fn = 'return fresh("'+proto.fresh+'", function('+vars+') {';
-    var test_fn = '('+to_string(proto.body)+')('+vars+')';
-    var expected = typeof(proto.expected) === 'function'?
-                    '('+to_string(proto.expected)+')('+vars+')':
-                    Objects.to_string(proto.expected);
-    var fresh_body = 'try { return assert_equals("'+name+'",'+test_fn+','+expected+'); } catch(e) { console.error("Exception raised during '+name+' -> "+e.stack); }';
-    console.log('with FRESH', new Function((fresh_fn+fresh_body+'})')));
-    console.log('with FRESH fresh_body', (fresh_body));
-    return new Function(fresh_fn+fresh_body+'});');
-  } else {
-    var test_fn = '('+to_string(proto.body)+')()';
-    var expected = typeof(proto.expected) === 'function'? // expected must be lazy when new classes
-                    '('+to_string(proto.expected)+')()':  // are instanciated otherwise
-                    Objects.to_string(proto.expected);    // the instanceof does not work..
-    var test_body = 'try { return assert_equals("'+name+'", '+
-                      test_fn+', '+
-                      expected+'); } catch(e) { console.error("Exception raised during '+name+' -> "+e.stack); }';
-    console.log('sans fresh whole function', new Function((test_body)))
-    console.log('sans fresh test_body', (test_body));
-    return new Function(test_body);
-  }
-  */
   function do_test ( ) {
     var handler = function ( ) {
       var expected = proto.expected.apply
@@ -327,47 +302,11 @@ var mk_test = function(proto, index) {
       }
     };
     if (proto.fresh && proto.body && proto.body.call) {
-      console.log('returning with fresh');
       return (function ( ) { return fresh(proto.fresh, handler); }).apply(this, arguments);
     } else {
       return handler.apply(this, arguments);
     }
   }
-  /*
-  function anonymous() {
-    return fresh("x y",
-      function($x, $y) {
-        try {
-          return assert_equals("test_0",
-            (function ($x, $y) {
-              return empty_bindings.unify($x, $y);
-            })($x, $y),
-            (function ($x, $y) {
-              return new Bindings(mk_assoc($x.name,  $y));
-            })($x, $y)
-          );
-        } catch(e) {
-          console.error("Exception raised during test_0 -> "+e.stack);
-        }
-      })
-    }
-  */
-  /* case 2, no fresh variables
-  function anonymous() {
-    try {
-      return assert_equals("test_6",
-        (function () {
-          return run(function($q) {
-            return choice($q, [1,2,3]);
-          });
-        })(),
-        [1,2,3]
-      );
-    } catch(e) {
-      console.error("Exception raised during test_6 -> "+e.stack);
-    }
-  }
-  */
 
   tests[name] = do_test;
   return tests[name];


### PR DESCRIPTION
The `new Function` idiom mucks with the scope chain in bad ways.
The javascript here is nicely, done, I especially like the prototype-based Binding, which will make it easier to play around with different `walk` and `lookup` implementations.

These changes replace the `new Function` idiom by setting up a special closure around the test context.  In node, this makes `fresh` and the other needed functions available in the closure's scope.
I tested the changes by changing the first `expected: 1` to `expected: 2` and watched the test fail as expected, then I changed it back so everything passes again.

Very cool, thanks!
